### PR TITLE
Issue #3 - Worker service to handle MQTT communication between ESP32 devices

### DIFF
--- a/backend/src/garage-door-extensions-backend-core/Options/AlertOptions.cs
+++ b/backend/src/garage-door-extensions-backend-core/Options/AlertOptions.cs
@@ -1,0 +1,5 @@
+public class AlertOptions
+{
+    public int GarageDoorOpenTimeoutSeconds { get; set; } = 120; // Default to 2 minutes
+    public string AlertMessage { get; set; } = "Garage door has been open for {duration} seconds!";  // Use {duration} as placeholder for duration in seconds
+}

--- a/backend/src/garage-door-extensions-backend-core/Options/MqttClientOptions.cs
+++ b/backend/src/garage-door-extensions-backend-core/Options/MqttClientOptions.cs
@@ -1,0 +1,9 @@
+public class MqttClientOptions
+{
+    public string BrokerAddress { get; set; }
+    public int Port { get; set; } = 1883;
+    public string ClientId { get; set; } = Guid.NewGuid().ToString();
+    public bool CleanSession { get; set; } = true;
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/backend/src/garage-door-extensions-service/Program.cs
+++ b/backend/src/garage-door-extensions-service/Program.cs
@@ -1,0 +1,15 @@
+using BlogEivindGLCom.GarageDoorExtensionsBackend.Service;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<Worker>();
+builder.Services.Configure<MqttClientOptions>(builder.Configuration.GetSection("MqttClientOptions"));
+builder.Services.Configure<AlertOptions>(builder.Configuration.GetSection("AlertOptions"));
+builder.Services.AddHttpClient(Worker.BackendApiHttpClient, client =>
+{
+    var configSection = builder.Configuration.GetSection("BackendApi");
+    client.BaseAddress = new Uri(configSection.GetValue<string>("BaseUri") ?? "http://localhost:80");
+    client.Timeout = TimeSpan.FromSeconds(5);
+});
+
+var host = builder.Build();
+host.Run();

--- a/backend/src/garage-door-extensions-service/Properties/launchSettings.json
+++ b/backend/src/garage-door-extensions-service/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "garage_door_extensions_service": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/backend/src/garage-door-extensions-service/Worker.cs
+++ b/backend/src/garage-door-extensions-service/Worker.cs
@@ -9,7 +9,8 @@ namespace BlogEivindGLCom.GarageDoorExtensionsBackend.Service;
 public class Worker : BackgroundService
 {
     internal const string BackendApiHttpClient = "BackendApi";
-    private const string GarageDoorMqttTopic = "garageDoor/doorStateChanged";
+    private const string GarageDoorStateChangedTopic = "garageDoor/doorStateChanged";
+    private const string GarageDoorDisplayTopic = "garageDoor/display";
     private const string AlertTopic = "garageDoor/alert";
     private const string AlertMessageDurationPlaceholder = "{duration}";
     private const string OpeningState = "opening";
@@ -57,7 +58,7 @@ public class Worker : BackgroundService
             .Build();
         _mqttClient.ApplicationMessageReceivedAsync += HandleIncomingMessageAsync;
         _mqttDoorStateSubscribeOptions = mqttFactory.CreateSubscribeOptionsBuilder()
-            .WithTopicFilter(GarageDoorMqttTopic).Build();
+            .WithTopicFilter(GarageDoorStateChangedTopic).Build();
     }
 
     private HttpClient GetHttpClient()
@@ -165,7 +166,7 @@ public class Worker : BackgroundService
                     
                     // Subscribe to the MQTT topic garageDoor/doorStateChanged
                     await _mqttClient.SubscribeAsync(_mqttDoorStateSubscribeOptions, stoppingToken);
-                    _logger.LogInformation($"Subscribed to topic: {GarageDoorMqttTopic}");
+                    _logger.LogInformation($"Subscribed to topic: {GarageDoorStateChangedTopic}");
                 }
             }
         }
@@ -193,7 +194,7 @@ public class Worker : BackgroundService
 
             // Publish an MQTT message to update the display counter
             await _mqttClient.PublishAsync(new MqttApplicationMessageBuilder()
-                .WithTopic(GarageDoorMqttTopic)
+                .WithTopic(GarageDoorDisplayTopic)
                 .WithPayload(displayData)
                 .WithQualityOfServiceLevel(MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce)
                 .Build(), stoppingToken);

--- a/backend/src/garage-door-extensions-service/Worker.cs
+++ b/backend/src/garage-door-extensions-service/Worker.cs
@@ -1,0 +1,312 @@
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.Extensions.Options;
+using MQTTnet;
+
+namespace BlogEivindGLCom.GarageDoorExtensionsBackend.Service;
+
+public class Worker : BackgroundService
+{
+    internal const string BackendApiHttpClient = "BackendApi";
+    private const string GarageDoorMqttTopic = "garageDoor/doorStateChanged";
+    private const string AlertTopic = "garageDoor/alert";
+    private const string AlertMessageDurationPlaceholder = "{duration}";
+    private const string OpeningState = "opening";
+    private const string ClosedState = "closed";
+    private const string OpeningApiEndpoint = "api/dooropenings/RegisterDoorOpening";
+    private const string ClosedApiEndpoint = "api/dooropenings/RegisterDoorClosing";
+    private const string DisplayApiEndpoint = "api/dooropenings/display";
+    private readonly MQTTnet.MqttClientOptions _mqttClientOptions;
+    private readonly MQTTnet.MqttClientSubscribeOptions _mqttDoorStateSubscribeOptions;
+    private IMqttClient _mqttClient;
+    private readonly IOptions<AlertOptions> _alertOptions;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<Worker> _logger;
+    private DateTime? _lastPing;
+    private DateTime? _lastAlertCheck;
+    private bool disposed = false;
+
+    public Worker(IOptions<MqttClientOptions> mqttClientOptions, IOptions<AlertOptions> alertOptions, IHttpClientFactory httpClientFactory, ILogger<Worker> logger)
+    {
+        if (mqttClientOptions == null) throw new ArgumentNullException(nameof(mqttClientOptions), "MqttClientOptions cannot be null");
+        if (alertOptions == null) throw new ArgumentNullException(nameof(alertOptions), "AlertOptions cannot be null");
+        _alertOptions = alertOptions;
+        if (httpClientFactory == null) throw new ArgumentNullException(nameof(httpClientFactory), "IHttpClientFactory cannot be null");
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+
+        // Validate AlertOptions
+        if (_alertOptions.Value.GarageDoorOpenTimeoutSeconds <= 0)
+        {
+            _logger.LogWarning("GarageDoorOpenTimeoutSeconds is not set or invalid, disabling alerts.");
+        }
+
+        // Validate and set up MQTT client options
+        if (string.IsNullOrWhiteSpace(mqttClientOptions.Value.BrokerAddress))
+        {
+            throw new ArgumentException("BrokerAddress cannot be null or empty", nameof(mqttClientOptions));
+        }
+
+        var mqttFactory = new MqttClientFactory();
+        _mqttClient = mqttFactory.CreateMqttClient();
+        _mqttClientOptions = new MqttClientOptionsBuilder()
+            .WithTcpServer(mqttClientOptions.Value.BrokerAddress, port: mqttClientOptions.Value.Port)
+            .WithCredentials(mqttClientOptions.Value.Username, mqttClientOptions.Value.Password)
+            .Build();
+        _mqttClient.ApplicationMessageReceivedAsync += HandleIncomingMessageAsync;
+        _mqttDoorStateSubscribeOptions = mqttFactory.CreateSubscribeOptionsBuilder()
+            .WithTopicFilter(GarageDoorMqttTopic).Build();
+    }
+
+    private HttpClient GetHttpClient()
+    {
+        return _httpClientFactory.CreateClient(BackendApiHttpClient);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // Connect to the MQTT broker and keep the connection alive
+            await ConnectAndKeepAliveAsync(stoppingToken);
+
+            // Publish MQTT message for failure when the garage door i not closed after a certain time
+            await AlertOnDoorNotClosedAsync(stoppingToken);
+
+            // Wait for a while before the next iteration
+            await Task.Delay(1000, stoppingToken);
+        }
+
+        // Ensure the MQTT client is disposed when the service stops
+        Dispose();
+    }
+    
+    private async Task HandleIncomingMessageAsync(MqttApplicationMessageReceivedEventArgs e)
+    {
+        try
+        {
+            var payload = Encoding.UTF8.GetString(e.ApplicationMessage.Payload);
+            _logger.LogInformation($"Received message on topic {e.ApplicationMessage.Topic}: {payload}");
+
+            if (OpeningState.Equals(payload, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogInformation("Garage door is opening.");
+
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15)))
+                {
+                    await RegisterDoorStateAsync(OpeningApiEndpoint, cts.Token);
+                }
+
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15)))
+                {
+                    await UpdateDisplayCounter(cts.Token);
+                }
+            }
+            else if (ClosedState.Equals(payload, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogInformation("Garage door is closed.");
+
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15)))
+                {
+                    await RegisterDoorStateAsync(ClosedApiEndpoint, cts.Token);
+                }
+            }
+            else
+            {
+                _logger.LogWarning($"Unknown state received: {payload}");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing incoming MQTT message");
+        }
+    }
+
+    private async Task RegisterDoorStateAsync(string relativeUri, CancellationToken stoppingToken)
+    {
+        try
+        {
+            using var httpClient = GetHttpClient();
+            var response = await httpClient.PostAsync(relativeUri, content: null, stoppingToken);
+            response.EnsureSuccessStatusCode();
+            _logger.LogInformation($"Successfully registered door state: {relativeUri}");
+        }
+        catch (Exception ex)
+        {
+            //  TODO: Use Polly to retry on failure
+            _logger.LogError(ex, $"Failed to register door state: {relativeUri} - {ex.Message}");
+        }
+    }
+
+    private async Task ConnectAndKeepAliveAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            // Ping every 5 seconds to test the connection and reconnect if necessary
+            if (!_lastPing.HasValue || _lastPing.Value.AddSeconds(5) < DateTime.UtcNow)
+            {
+                _lastPing = DateTime.UtcNow;
+
+                // This code will also do the very first connect! So no call to _ConnectAsync_ is required in the first place.
+                if (!await _mqttClient.TryPingAsync(stoppingToken))
+                {
+                    _logger.LogInformation("MQTT client is not connected, attempting to connect...");
+                    var result = await _mqttClient.ConnectAsync(_mqttClientOptions, stoppingToken);
+
+                    if (result.ResultCode != MQTTnet.MqttClientConnectResultCode.Success)
+                    {
+                        _logger.LogError($"Failed to connect to MQTT broker: {result.ReasonString}");
+                        return; // Exit if connection fails
+                    }
+
+                    _logger.LogInformation("The MQTT client is connected.");
+                    
+                    // Subscribe to the MQTT topic garageDoor/doorStateChanged
+                    await _mqttClient.SubscribeAsync(_mqttDoorStateSubscribeOptions, stoppingToken);
+                    _logger.LogInformation($"Subscribed to topic: {GarageDoorMqttTopic}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"An error occurred while connecting to the MQTT broker. {ex.Message}");
+        }
+    }
+    
+    private async Task UpdateDisplayCounter(CancellationToken stoppingToken)
+    {
+        try
+        {
+            // Call API to build MQTT message to update the display counter
+            using var httpClient = GetHttpClient();
+            var response = await httpClient.GetAsync(DisplayApiEndpoint, stoppingToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError($"Failed to get display data: {response.ReasonPhrase}");
+                return;
+            }
+
+            var displayData = await response.Content.ReadAsStringAsync(stoppingToken);
+
+            // Publish an MQTT message to update the display counter
+            await _mqttClient.PublishAsync(new MqttApplicationMessageBuilder()
+                .WithTopic(GarageDoorMqttTopic)
+                .WithPayload(displayData)
+                .WithQualityOfServiceLevel(MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce)
+                .Build(), stoppingToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error updating display counter");
+        }
+    }
+
+    private async Task AlertOnDoorNotClosedAsync(CancellationToken stoppingToken)
+    {
+        if (_alertOptions.Value.GarageDoorOpenTimeoutSeconds <= 0)
+        {
+            return;
+        }
+
+        // Check if the last alert check was more than the configured timeout ago
+        // This prevents multiple alerts within the timeout period
+        // Add one second to ensure we don't miss the alert if the door is open exactly at the timeout
+        if (!_lastAlertCheck.HasValue || _lastAlertCheck.Value.AddSeconds(_alertOptions.Value.GarageDoorOpenTimeoutSeconds + 1) < DateTime.UtcNow)
+        {
+            _lastAlertCheck = DateTime.UtcNow;
+
+            // Check if the door has been open for too long
+            using var httpClient = GetHttpClient();
+            var response = await httpClient.GetAsync("api/dooropenings/openduration", stoppingToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError($"Failed to get door open duration: {response.ReasonPhrase}");
+                return;
+            }
+
+            var openDuration = await response.Content.ReadAsStringAsync(stoppingToken);
+
+            if (int.TryParse(openDuration, out int duration) && duration < _alertOptions.Value.GarageDoorOpenTimeoutSeconds)
+            {
+                _logger.LogInformation($"Garage door has been open for {duration} seconds, which is less than the configured timeout of {_alertOptions.Value.GarageDoorOpenTimeoutSeconds} seconds.");
+                return; // No alert needed
+            }
+
+            _logger.LogWarning($"Garage door has been open for {openDuration} seconds, sending alert...");
+
+            // Publish an alert message to the MQTT broker
+            string? alertMessageContent = null;
+
+            if (!string.IsNullOrWhiteSpace(_alertOptions.Value.AlertMessage))
+            {
+                alertMessageContent = _alertOptions.Value.AlertMessage.Replace(AlertMessageDurationPlaceholder, openDuration);
+            }
+
+            var alertMessage = new MqttApplicationMessageBuilder()
+                .WithTopic(AlertTopic)
+                .WithPayload(alertMessageContent ?? openDuration)
+                .WithQualityOfServiceLevel(MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce)
+                .Build();
+
+            await _mqttClient.PublishAsync(alertMessage, stoppingToken);
+        }
+    }
+
+    // Protected Dispose method (core cleanup logic)
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposed)
+        {
+            if (disposing)
+            {
+                // Dispose managed resources
+                if (_mqttClient != null)
+                {
+                    try
+                    {
+                        _logger.LogInformation("Disconnecting MQTT client...");
+
+                        // This will send the DISCONNECT packet. Calling _Dispose_ without DisconnectAsync the
+                        // connection is closed in a "not clean" way. See MQTT specification for more details.
+                        using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
+                        {
+                            _mqttClient.DisconnectAsync(
+                                new MqttClientDisconnectOptionsBuilder()
+                                    .WithReason(MqttClientDisconnectOptionsReason.NormalDisconnection)
+                                    .Build(),
+                                cancellationToken: cts.Token).GetAwaiter().GetResult();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to disconnect MQTT client gracefully.");
+                    }
+
+                    _mqttClient?.Dispose();
+                }
+            }
+
+            // Free unmanaged resources
+            _mqttClient = null!; // Using null-forgiving operator since we're disposing
+            disposed = true;
+        }
+    }
+
+    // Finalizer (called by the garbage collector)
+/*     ~Worker()
+    {
+        Dispose(false); // Dispose only unmanaged resources
+    } */
+    
+    
+    // Public Dispose method (called explicitly)
+    public override void Dispose()
+    {
+        Dispose(true); // Dispose managed and unmanaged resources
+        base.Dispose(); // Call base Dispose to clean up the base class
+        GC.SuppressFinalize(this); // Suppress finalization
+    }
+}

--- a/backend/src/garage-door-extensions-service/appsettings.Development.json
+++ b/backend/src/garage-door-extensions-service/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/backend/src/garage-door-extensions-service/appsettings.json
+++ b/backend/src/garage-door-extensions-service/appsettings.json
@@ -1,0 +1,23 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "MqttClientOptions": {
+    "BrokerAddress": "localhost",
+    "Port": 1883,
+    "ClientId": "GarageDoorExtensionsService",
+    "CleanSession": true,
+    "Username": "",
+    "Password": ""
+  },
+  "AlertOptions": {
+    "GarageDoorOpenTimeoutSeconds": 30,
+    "AlertMessage": "The garage door has been open for {duration} seconds."
+  },
+  "BackendApi":{
+    "BaseUri": "http://localhost:5035"
+  }  
+}

--- a/backend/src/garage-door-extensions-service/garage-door-extensions-service.csproj
+++ b/backend/src/garage-door-extensions-service/garage-door-extensions-service.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dotnet-garage_door_extensions_service-238dd4f6-4407-4fd9-a11e-8a241703f3b4</UserSecretsId>
+    <RootNamespace>BlogEivindGLCom.GarageDoorExtensionsBackend.Service</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.7" />
+    <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../garage-door-extensions-backend-core/garage-door-extensions-backend-core.csproj" />
+  </ItemGroup>
+</Project>

--- a/backend/src/garage-door-extensions.sln
+++ b/backend/src/garage-door-extensions.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "garage-door-extensions-back
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "garage-door-extensions-backend-core", "garage-door-extensions-backend-core\garage-door-extensions-backend-core.csproj", "{C4B0EAEC-FEC6-4DC0-9729-4ACC45898E73}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "garage-door-extensions-service", "garage-door-extensions-service\garage-door-extensions-service.csproj", "{B7C79EDC-2C6A-4109-BD73-28CA5C0279BC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{C4B0EAEC-FEC6-4DC0-9729-4ACC45898E73}.Release|x64.Build.0 = Release|Any CPU
 		{C4B0EAEC-FEC6-4DC0-9729-4ACC45898E73}.Release|x86.ActiveCfg = Release|Any CPU
 		{C4B0EAEC-FEC6-4DC0-9729-4ACC45898E73}.Release|x86.Build.0 = Release|Any CPU
+		{B7C79EDC-2C6A-4109-BD73-28CA5C0279BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7C79EDC-2C6A-4109-BD73-28CA5C0279BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7C79EDC-2C6A-4109-BD73-28CA5C0279BC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B7C79EDC-2C6A-4109-BD73-28CA5C0279BC}.Debug|x64.Build.0 = Debug|Any CPU
+		{B7C79EDC-2C6A-4109-BD73-28CA5C0279BC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B7C79EDC-2C6A-4109-BD73-28CA5C0279BC}.Debug|x86.Build.0 = Debug|Any CPU
+		{B7C79EDC-2C6A-4109-BD73-28CA5C0279BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7C79EDC-2C6A-4109-BD73-28CA5C0279BC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7C79EDC-2C6A-4109-BD73-28CA5C0279BC}.Release|x64.ActiveCfg = Release|Any CPU
+		{B7C79EDC-2C6A-4109-BD73-28CA5C0279BC}.Release|x64.Build.0 = Release|Any CPU
+		{B7C79EDC-2C6A-4109-BD73-28CA5C0279BC}.Release|x86.ActiveCfg = Release|Any CPU
+		{B7C79EDC-2C6A-4109-BD73-28CA5C0279BC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Provides backend to handle door state changes and update display for issue #3 
 - Subscribes to MQTT topic garageDoor/doorStateChanged from door sensor module
 - Subscribes to MQTT topic garageDoor/queryState from display module (used when display is reset or power outage etc)
 - Publishes to MQTT topic garageDoor/display to update the display with counters
 - Publishes to MQTT topic garageDoor/alert, but nothing subscribes to this topic to actually send alerts. The display module must monitor the emergency stop button on the garage door to avoid sending alerts when someone uses that button to keep the door open intentionally.
 