### PR TITLE
Issue #8 - Backend part of updating doors with valid rfid cards

### DIFF
--- a/backend/src/garage-door-extensions-backend-services/GarageDoorExtensionsDbContext.cs
+++ b/backend/src/garage-door-extensions-backend-services/GarageDoorExtensionsDbContext.cs
@@ -31,4 +31,15 @@ public class GarageDoorExtensionsDbContext : DbContext
             .HasForeignKey(v => v.Rfid)
             .OnDelete(DeleteBehavior.Cascade);
     }
+
+    public async Task<string> GetValidRfidCardsForDoorAsync(string doorId)
+    {
+        // Implementation to retrieve valid RFID cards for a specific door
+        return string.Join("\n", await RfidCardValidForDoors
+            .Where(v => v.DoorId == doorId && v.ValidFrom <= DateTime.UtcNow && (DateTime.UtcNow <= v.ValidTo || v.ValidTo == null))
+            .OrderBy(v => v.Rfid)
+            .Select(v => v.Rfid)
+            .Distinct()
+            .ToListAsync());
+    }
 }

--- a/backend/src/garage-door-extensions-backend-services/RfidStorageFileSystemService.cs
+++ b/backend/src/garage-door-extensions-backend-services/RfidStorageFileSystemService.cs
@@ -10,6 +10,7 @@ public class RfidStorageFileSystemService : IRfidStorage
     private readonly ILogger<RfidStorageFileSystemService> _logger;
     private readonly IDateTimeService _dateTimeService;
     private string _invalidRfidsPath;
+    private string _validRfidsPath;
 
     public RfidStorageFileSystemService(IOptions<RfidStorageFileSystemOptions> options, ILogger<RfidStorageFileSystemService> logger, IDateTimeService dateTimeService)
     {
@@ -26,6 +27,7 @@ public class RfidStorageFileSystemService : IRfidStorage
             basePath = Path.Combine(AppContext.BaseDirectory, "data");
         }
         _invalidRfidsPath = Path.Combine(basePath, "invalid-rfids");
+        _validRfidsPath = Path.Combine(basePath, "valid-rfids");
     }
 
     public void StoreRfid(string rfid)

--- a/backend/src/garage-door-extensions-backend/Controllers/DoorsController.cs
+++ b/backend/src/garage-door-extensions-backend/Controllers/DoorsController.cs
@@ -1,16 +1,30 @@
 using BlogEivindGLCom.GarageDoorExtensionsBackend.Model;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using MQTTnet;
 
 [ApiController]
 [Route("api/[controller]")]
 public class DoorsController : ControllerBase
 {
+    private const string QueryValidRfidCardsTopic = "garageDoor/queryValidRfidCards";
     private readonly GarageDoorExtensionsDbContext _dbContext;
+    private readonly IMqttClient _mqttClient;
+    private readonly MQTTnet.MqttClientOptions _mqttClientOptions;
+    private readonly ILogger<DoorsController> _logger;
 
-    public DoorsController(GarageDoorExtensionsDbContext dbContext)
+    public DoorsController(GarageDoorExtensionsDbContext dbContext, IOptions<MqttClientOptions> mqttClientOptions, ILogger<DoorsController> logger)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var mqttFactory = new MqttClientFactory();
+        _mqttClient = mqttFactory.CreateMqttClient();
+        _mqttClientOptions = new MqttClientOptionsBuilder()
+            .WithTcpServer(mqttClientOptions.Value.BrokerAddress, port: mqttClientOptions.Value.Port)
+            .WithCredentials(mqttClientOptions.Value.Username, mqttClientOptions.Value.Password)
+            .Build();
     }
 
     [HttpGet]
@@ -92,26 +106,32 @@ public class DoorsController : ControllerBase
         return NoContent();
     }
 
-   [HttpPost("{doorId}/publishValidRfidCards")]
-   public async Task<IActionResult> PublishValidRfidCards(string doorId)
+   [HttpPost("publishValidRfidCards")]
+   public async Task<IActionResult> PublishValidRfidCards()
    {
-        if (string.IsNullOrWhiteSpace(doorId))
-        {
-            return BadRequest("Invalid door ID.");
-        }
+        _logger.LogInformation("MQTT client is not connected, attempting to connect...");
 
-        var door = await _dbContext.Doors.FindAsync(doorId);
-        if (door == null)
+        // Publish a message to have all doors query their valid RFID cards
+        using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
         {
-            return NotFound();
-        }
+            var result = await _mqttClient.ConnectAsync(_mqttClientOptions, cts.Token);
 
-        // TODO: Publish a message to have the worker service explicitly update the specified door's valid RFID cards.
-        /*await _mqttClient.PublishAsync(new MqttApplicationMessageBuilder()
-            .WithTopic($"garageDoor/updateValidRfidCards/{doorId}")
-            .WithPayload("")
-            .WithAtLeastOnceQoS()
-            .Build());*/
+            if (result.ResultCode != MQTTnet.MqttClientConnectResultCode.Success)
+            {
+                _logger.LogError($"Failed to connect to MQTT broker: {result.ReasonString}");
+                return StatusCode(500, "Failed to connect to MQTT broker."); // Exit if connection fails
+            }
+
+            _logger.LogInformation("The MQTT client is connected.");
+
+            await _mqttClient.PublishAsync(new MqttApplicationMessageBuilder()
+               .WithTopic(QueryValidRfidCardsTopic)
+               .Build(), cts.Token);
+       
+            await _mqttClient.DisconnectAsync();
+        } 
+
+        _logger.LogInformation("Published MQTT message for all doors to query valid RFID cards.");
 
         return NoContent();
    }

--- a/backend/src/garage-door-extensions-backend/Controllers/DoorsController.cs
+++ b/backend/src/garage-door-extensions-backend/Controllers/DoorsController.cs
@@ -91,4 +91,28 @@ public class DoorsController : ControllerBase
         await _dbContext.SaveChangesAsync();
         return NoContent();
     }
+
+   [HttpPost("{doorId}/publishValidRfidCards")]
+   public async Task<IActionResult> PublishValidRfidCards(string doorId)
+   {
+        if (string.IsNullOrWhiteSpace(doorId))
+        {
+            return BadRequest("Invalid door ID.");
+        }
+
+        var door = await _dbContext.Doors.FindAsync(doorId);
+        if (door == null)
+        {
+            return NotFound();
+        }
+
+        // TODO: Publish a message to have the worker service explicitly update the specified door's valid RFID cards.
+        /*await _mqttClient.PublishAsync(new MqttApplicationMessageBuilder()
+            .WithTopic($"garageDoor/updateValidRfidCards/{doorId}")
+            .WithPayload("")
+            .WithAtLeastOnceQoS()
+            .Build());*/
+
+        return NoContent();
+   }
 }

--- a/backend/src/garage-door-extensions-backend/Program.cs
+++ b/backend/src/garage-door-extensions-backend/Program.cs
@@ -54,6 +54,9 @@ switch (rfidStorageServiceType)
         throw new InvalidOperationException("Invalid RfidStorageService type configured");
 }
 
+// MQTT Client for DoorsController
+builder.Services.Configure<MqttClientOptions>(builder.Configuration.GetSection("MqttClientOptions"));
+
 builder.Services.AddControllers(); // This supports attribute routing better than AddControllersWithViews for APIs
 builder.Services.AddControllersWithViews();
 

--- a/backend/src/garage-door-extensions-backend/appsettings.json
+++ b/backend/src/garage-door-extensions-backend/appsettings.json
@@ -9,6 +9,14 @@
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=./data/garage_door_extensions.db"
   },
+  "MqttClientOptions": {
+    "BrokerAddress": "localhost",
+    "Port": 1883,
+    "ClientId": "GarageDoorExtensionsApi",
+    "CleanSession": true,
+    "Username": "",
+    "Password": ""
+  },
   "DoorOpeningsService":{
     "Type": "FileSystem",
     "BasePath": "./data"

--- a/backend/src/garage-door-extensions-backend/garage-door-extensions-backend.csproj
+++ b/backend/src/garage-door-extensions-backend/garage-door-extensions-backend.csproj
@@ -11,4 +11,8 @@
     <ProjectReference Include="../garage-door-extensions-backend-services/garage-door-extensions-backend-services.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- Backend API got access to MQTT broker to publish a message that triggers all doors to query for changes to their list of valid RFID cards
- Backend service got logic to query all doors for their list of valid RFID cards every night after midnight in case some RFID cards expired that date. RFID modules responds and backend service queries API for each door to get their current valid RFID cards and then compares with each door's current list and decides whether to publish an update message for any door.