### PR TITLE
Issue #25 - Fix solder error and documentation

### DIFF
--- a/Sketches/rfid_and_door_sensor_module.md
+++ b/Sketches/rfid_and_door_sensor_module.md
@@ -14,7 +14,7 @@ RFID and door sensor module is complete on breadboards.
 ## RFID-RC522 module is visualized as an 8-pin header in the sketch.
  - SDA is the yellow wire connected to the ESP32 pin D5
  - SCK is the white wire connected to the ESP32 pin D18
- - MOSI is the green wire connected to the ESP32 pin D22
+ - MOSI is the green wire connected to the ESP32 pin D23
  - MISO is the blue wire connected to the ESP32 pin D19
  - IRQ is not connected
  - GND is the black wire connected to ESP32 GND pin through the breadboard


### PR DESCRIPTION
It looks like pin 22 is connected to MOSI on the RFID board, but it's actually pin 23. The Tinkercad pin header component has one more pin than is on the ESP32 WROOM D32 board:
<img width="592" height="142" alt="image" src="https://github.com/user-attachments/assets/1477eef5-4bc1-4aeb-8ec3-176f2bb1dbb9" />

So the solder error must be fixed and then hopefully the module will work when wired up to the perfboard.